### PR TITLE
fix: update xssec mock to support ias-auth.js changes

### DIFF
--- a/test/__mocks__/xssec.js
+++ b/test/__mocks__/xssec.js
@@ -5,10 +5,38 @@ class IdentityService {
   }
 }
 
+class XsuaaService {
+  constructor(credentials, config) {
+    this.credentials = credentials
+    this.config = config
+  }
+}
+
+class XsuaaToken {
+  constructor() {}
+}
+
 class ValidationError extends Error {
   constructor(message = 'Invalid token') {
     super(message)
     this.name = 'ValidationError'
+  }
+}
+
+class ExpiredTokenError extends Error {
+  constructor(message = 'Token expired') {
+    super(message)
+    this.name = 'ExpiredTokenError'
+    this.token = {
+      getZoneId: () => 'dummyZoneId'
+    }
+  }
+}
+
+const Token = {
+  decodeCache: null,
+  enableDecodeCache() {
+    this.decodeCache = true
   }
 }
 
@@ -26,6 +54,9 @@ module.exports = {
     }
     return { token: dummyTokenInfo }
   },
+  Token,
   IdentityService,
-  errors: { ValidationError }
+  XsuaaService,
+  XsuaaToken,
+  errors: { ValidationError, ExpiredTokenError }
 }


### PR DESCRIPTION
## Summary
Updates the xssec mock to include missing classes and properties required by the updated ias-auth.js file.

The ias-auth.js file was modified to use additional xssec API components that were not present in the test mock, causing test failures. This PR adds minimal mock implementations for the missing components to make tests pass again.

### Changes
- Added `Token` object with `decodeCache` property and `enableDecodeCache()` method
- Added `XsuaaService` and `XsuaaToken` classes with basic constructors
- Added `ExpiredTokenError` class with required `token.getZoneId()` method

### Fixes
- event-broker-ias-single-tenant test failures
- event-broker-ias-multitenant test failures  
- event-broker-error-handling test failures

All tests now pass (30/30).

fyi @sjvans @David-Kunz  