### PR TITLE
feat(event-broker): add compliance header support for event emission

### DIFF
--- a/test/event-broker-ias-single-tenant/default-env.json
+++ b/test/event-broker-ias-single-tenant/default-env.json
@@ -3,6 +3,8 @@
     "event-broker": [
       {
         "credentials": {
+          "systemId": "321",
+          "ceSource": ["/default/cap.test"],
           "authentication-type": "X509_IAS",
           "eventing": {
             "http": {

--- a/test/event-broker-ias-single-tenant/event-broker.test.js
+++ b/test/event-broker-ias-single-tenant/event-broker.test.js
@@ -48,13 +48,26 @@ describe('event-broker service with ias auth for single tenant scenario', () => 
     mockHttps.handleHttpReq = () => {
       return { message: 'ok' }
     }
-    cds.context = { tenant: 't1', user: cds.User.privileged }
-    try {
+    cds.context = { tenant: 'btpSystemId', user: cds.User.privileged }
+    
       await ownSrv.emit('created', { data: 'testdata', headers: { some: 'headers' } })
-      expect(1).toBe('Should not be supported')
-    } catch (e) {
-      expect(e.message).toMatch(/not supported/)
-    }
+    expect(mockHttps.request).toHaveBeenCalledTimes(1)
+    expect(mockHttps.request).toHaveBeenCalledWith(
+      {
+        hostname: 'eb-url.com',
+        method: 'POST',
+        headers: {
+          'ce-xsapcomplianteventspec': true,
+          'ce-id': expect.anything(),
+          'ce-source': '/default/cap.test/btpSystemId',
+          'ce-type': 'cap.test.object.created.v1',
+          'ce-specversion': '1.0',
+          'Content-Type': 'application/json'
+        },
+        agent: messaging.agent
+      },
+      expect.anything()
+    )
   })
 
   test('no creds and emit from app service', async () => {


### PR DESCRIPTION
# Summary

Adds support for `ce-xsapcomplianteventspec` header in Event Hub emissions for event-connectivity plan.

The Event Hub service now conditionally adds the `ce-xsapcomplianteventspec` header with value `true` when emitting events for services that have a `systemId` in their credentials. This header is required for compliance with SAP event specifications when using the event-connectivity plan for customers.

## Changes

- **Modified `emitToEventBroker()` method** to accept an optional `addComplianceHeader` boolean parameter
- **Updated `handle()` method** to determine when compliance header should be added based on presence of `credentials.systemId`
- **Added conditional header logic** to include `ce-xsapcomplianteventspec: true` when `systemId` is present in service credentials
- **Updated test configuration** to include `systemId: "321"` in event-broker-ias-single-tenant default-env.json
- **Enhanced test expectations** to verify the presence of `ce-xsapcomplianteventspec` header in emitted events

## Technical Details

The implementation uses a clean, encapsulated approach:
- Services with `credentials.systemId` (event-connectivity plan) → adds compliance header
- Services without `credentials.systemId` (event-mesh-multi-tenant plan) → no compliance header
- Boolean parameter pattern maintains separation of concerns