### PR TITLE
feat: Add ORD Integration Dependency support via CDS annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
-      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f @sap/cds@8 @cap-js/sqlite@1; fi
-      - run: cds v
+      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f --legacy-peer-deps @sap/cds@8 @cap-js/sqlite@1; fi
+      - run: npx cds v
       - run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm i
       - run: npm run lint
   test:
@@ -25,11 +25,11 @@ jobs:
         node-version: [22.x, 20.x]
         cds-version: [9, 8]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i
-      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i --legacy-peer-deps @sap/cds@8 @cap-js/sqlite@1; fi
+      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm pkg set devDependencies["@sap/cds"]="8" devDependencies["@cap-js/sqlite"]="1"; fi
+      - run: npm i --legacy-peer-deps
       - run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i
-      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f --legacy-peer-deps @sap/cds@8 @cap-js/sqlite@1; fi
-      - run: npx cds v
+      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i --legacy-peer-deps @sap/cds@8 @cap-js/sqlite@1; fi
       - run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm pkg set devDependencies["@sap/cds"]="8" devDependencies["@cap-js/sqlite"]="1"; fi
+      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm pkg set devDependencies["@sap/cds"]="8" devDependencies["@cap-js/sqlite"]="1" devDependencies["@cap-js/cds-test"]="0"; fi
       - run: npm i
       - run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm pkg set devDependencies["@sap/cds"]="8" devDependencies["@cap-js/sqlite"]="1"; fi
-      - run: npm i --legacy-peer-deps
+      - run: npm i
       - run: npm run test

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ At runtime, when services are served, the Event Broker plugin:
 
 1. Collects all event subscriptions registered via `messaging.subscribe()` with `eventResourceOrdId` option
 2. Groups event types by their event resource ORD ID
-3. Registers the eventResources with the ORD plugin's Extension API
+3. Publishes the Integration Dependency via the CDS event `ord.extension.publish`
 
 ### Example ORD Output
 

--- a/README.md
+++ b/README.md
@@ -82,41 +82,60 @@ If the parameter is not set, the [global request body size limit](https://pages.
 
 When both `@cap-js/event-broker` and `@cap-js/ord` plugins are installed, the Event Broker plugin can expose consumed events as an **Integration Dependency** in the ORD document.
 
-### Configuration via CDS Annotation
+### Using messaging.subscribe()
 
-To enable ORD Integration Dependencies, annotate consumed event definitions in your CDS model with `@ORD.Extensions.eventResource`. This maps your subscribed event types to their corresponding ORD event resource identifiers.
+Use the `subscribe()` method instead of `messaging.on()` to declare event subscriptions with ORD metadata in a single place:
 
-```cds
-// srv/services.cds
+```javascript
+// srv/server.js
+const cds = require("@sap/cds");
 
-// External events consumed from SAP S/4HANA via Event Broker
-event sap.s4.beh.businesspartner.v1.BusinessPartner.Changed.v1
-    @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1';
+cds.on("loaded", async () => {
+  const messaging = await cds.connect.to("messaging");
 
-event sap.s4.beh.businesspartner.v1.BusinessPartner.Created.v1
-    @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1';
-
-event sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1
-    @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_SALESORDEREVENTS:v1';
+  // Subscribe to event with ORD Integration Dependency metadata
+  messaging.subscribe(
+    "sap.s4.beh.businesspartner.v1.BusinessPartner.Changed.v1",
+    {
+      eventResourceOrdId: "sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1",
+    },
+    async (event) => {
+      console.log("Event received:", event);
+    },
+  );
+});
 ```
 
-The `ordId` values should match the event resource identifiers from the SAP Business Accelerator Hub or your event source's ORD document.
+The `eventResourceOrdId` value should match the event resource identifier from the SAP Business Accelerator Hub or your event source's ORD document.
+
+### Multiple Event Types per Event Resource
+
+A single event resource can contain multiple event types. Simply use the same `eventResourceOrdId` for related events:
+
+```javascript
+// Both events belong to the same CE_BUSINESSPARTNEREVENTS resource
+messaging.subscribe(
+  "sap.s4.beh.businesspartner.v1.BusinessPartner.Changed.v1",
+  { eventResourceOrdId: "sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1" },
+  handleBPChanged,
+);
+
+messaging.subscribe(
+  "sap.s4.beh.businesspartner.v1.BusinessPartner.Created.v1",
+  { eventResourceOrdId: "sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1" },
+  handleBPCreated,
+);
+```
+
+The plugin automatically groups event types by their `eventResourceOrdId`.
 
 ### How it works
 
 At runtime, when services are served, the Event Broker plugin:
 
-1. Scans the CDS model for events annotated with `@ORD.Extensions.eventResource`
-2. Collects all subscribed event topics from active messaging services
-3. Matches subscribed events against the annotated event definitions
-4. Registers the matching eventResources with the ORD plugin's Extension API
-
-Only events that are both:
-
-- Annotated with `@ORD.Extensions.eventResource` in CDS AND
-- Actually subscribed by your application
-
-will appear in the ORD document. Events that are subscribed but not annotated will trigger a warning log.
+1. Collects all event subscriptions registered via `messaging.subscribe()` with `eventResourceOrdId` option
+2. Groups event types by their event resource ORD ID
+3. Registers the eventResources with the ORD plugin's Extension API
 
 ### Example ORD Output
 
@@ -135,6 +154,9 @@ will appear in the ORD document. Events that are subscribed but not annotated wi
               "subset": [
                 {
                   "eventType": "sap.s4.beh.businesspartner.v1.BusinessPartner.Changed.v1"
+                },
+                {
+                  "eventType": "sap.s4.beh.businesspartner.v1.BusinessPartner.Created.v1"
                 }
               ]
             }
@@ -146,9 +168,9 @@ will appear in the ORD document. Events that are subscribed but not annotated wi
 }
 ```
 
-### No Annotation = No Integration Dependency
+### Backwards Compatibility
 
-If no events are annotated with `@ORD.Extensions.eventResource`, no Integration Dependency will be generated. This is intentional - the annotation ensures that event resources are properly mapped to their official ORD identifiers.
+The `subscribe()` method is **non-breaking** - existing code using `messaging.on()` continues to work. However, only events registered via `messaging.subscribe()` with the `eventResourceOrdId` option will appear in the ORD Integration Dependency.
 
 ## Support, Feedback, Contributing
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more information, please see [SAP Cloud Application Event Hub](https://help.
 
 ### webhookSizeLimit
 
-To set a size limit for events accepted by the webhook, set the ``webhookSizeLimit``parameter in the ``package.json`` file in the root folder of your app, e.g.
+To set a size limit for events accepted by the webhook, set the `webhookSizeLimit`parameter in the `package.json` file in the root folder of your app, e.g.
 
 ```jsonc
 "cds": {
@@ -76,7 +76,79 @@ To set a size limit for events accepted by the webhook, set the ``webhookSizeLim
 }
 ```
 
-If the parameter is not set, the [global request body size limit](https://pages.github.tools.sap/cap/docs/node.js/cds-server#maximum-request-body-size) ``cds.env.server.body_parser.limit`` is taken into account. If this parameter is not set either, the default value of ``1mb``is used.
+If the parameter is not set, the [global request body size limit](https://pages.github.tools.sap/cap/docs/node.js/cds-server#maximum-request-body-size) `cds.env.server.body_parser.limit` is taken into account. If this parameter is not set either, the default value of `1mb`is used.
+
+## ORD Integration
+
+When both `@cap-js/event-broker` and `@cap-js/ord` plugins are installed, the Event Broker plugin can expose consumed events as an **Integration Dependency** in the ORD document.
+
+### Configuration via CDS Annotation
+
+To enable ORD Integration Dependencies, annotate consumed event definitions in your CDS model with `@ORD.Extensions.eventResource`. This maps your subscribed event types to their corresponding ORD event resource identifiers.
+
+```cds
+// srv/services.cds
+
+// External events consumed from SAP S/4HANA via Event Broker
+event sap.s4.beh.businesspartner.v1.BusinessPartner.Changed.v1
+    @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1';
+
+event sap.s4.beh.businesspartner.v1.BusinessPartner.Created.v1
+    @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1';
+
+event sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1
+    @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_SALESORDEREVENTS:v1';
+```
+
+The `ordId` values should match the event resource identifiers from the SAP Business Accelerator Hub or your event source's ORD document.
+
+### How it works
+
+At runtime, when services are served, the Event Broker plugin:
+
+1. Scans the CDS model for events annotated with `@ORD.Extensions.eventResource`
+2. Collects all subscribed event topics from active messaging services
+3. Matches subscribed events against the annotated event definitions
+4. Registers the matching eventResources with the ORD plugin's Extension API
+
+Only events that are both:
+
+- Annotated with `@ORD.Extensions.eventResource` in CDS AND
+- Actually subscribed by your application
+
+will appear in the ORD document. Events that are subscribed but not annotated will trigger a warning log.
+
+### Example ORD Output
+
+```json
+{
+  "integrationDependencies": [
+    {
+      "ordId": "customer.myapp:integrationDependency:consumedEvents:v1",
+      "title": "Consumed Events",
+      "aspects": [
+        {
+          "title": "Subscribed Event Types",
+          "eventResources": [
+            {
+              "ordId": "sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1",
+              "subset": [
+                {
+                  "eventType": "sap.s4.beh.businesspartner.v1.BusinessPartner.Changed.v1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### No Annotation = No Integration Dependency
+
+If no events are annotated with `@ORD.Extensions.eventResource`, no Integration Dependency will be generated. This is intentional - the annotation ensures that event resources are properly mapped to their official ORD identifiers.
 
 ## Support, Feedback, Contributing
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -352,4 +352,258 @@ class EventBroker extends cds.MessagingService {
   }
 }
 
+// ============================================================================
+// ORD Integration Dependency Provider
+// ============================================================================
+
+/**
+ * Known Event Broker service kinds
+ */
+const EVENT_BROKER_KINDS = ['event-broker', 'event-broker-ias']
+
+/**
+ * Get all Event Broker messaging service configurations from cds.env.requires
+ * @returns {Array} Array of { name, config } objects
+ */
+function getEventBrokerConfigs() {
+  const envRequires = cds.env?.requires
+  if (!envRequires) return []
+
+  const configs = []
+  for (const [name, config] of Object.entries(envRequires)) {
+    if (!config || typeof config !== 'object') continue
+
+    const isEventBroker =
+      (config.kind && EVENT_BROKER_KINDS.includes(config.kind)) ||
+      (config.vcap?.label && EVENT_BROKER_KINDS.some(kind => config.vcap.label.includes(kind)))
+
+    if (isEventBroker) {
+      configs.push({ name, config })
+    }
+  }
+
+  return configs
+}
+
+/**
+ * Extract namespace from Event Broker credentials ceSource.
+ *
+ * ceSource format: "/default/<namespace>/..." or array with such strings
+ * Examples:
+ *   "/default/sap.s4/source-system" -> "sap.s4"
+ *   ["/default/beb-demo-nodejs/local"] -> "beb-demo-nodejs"
+ *
+ * @returns {string|null} Extracted namespace or null
+ */
+function extractNamespaceFromCeSource() {
+  const configs = getEventBrokerConfigs()
+
+  for (const { config } of configs) {
+    const credentials = config.credentials
+    if (!credentials) continue
+
+    // ceSource can be a string or an array
+    const ceSource = Array.isArray(credentials.ceSource) ? credentials.ceSource[0] : credentials.ceSource
+    if (!ceSource || typeof ceSource !== 'string') continue
+
+    // Parse ceSource: "/default/<namespace>/..." or "/<namespace>/..."
+    const parts = ceSource.split('/').filter(Boolean)
+    if (parts.length < 2) continue
+
+    // If first part is "default", namespace is second part, otherwise first part
+    const namespace = parts[0] === 'default' ? parts[1] : parts[0]
+    if (namespace) return namespace
+  }
+
+  return null
+}
+
+/**
+ * Get subscribed topics from Event Broker messaging services at runtime.
+ * Reads the subscribedTopics property from initialized messaging services.
+ *
+ * @returns {Array<string>} Array of subscribed topic names
+ */
+function getSubscribedTopics() {
+  const services = cds.services
+  if (!services) return []
+
+  const topics = new Set()
+  const configs = getEventBrokerConfigs()
+
+  for (const { name } of configs) {
+    const service = services[name]
+    if (!service || typeof service.subscribedTopics === 'undefined') continue
+
+    const subscribedTopics = service.subscribedTopics
+
+    if (subscribedTopics instanceof Map) {
+      for (const topic of subscribedTopics.keys()) {
+        if (topic && topic !== '*' && !topic.includes('messaging/error')) {
+          topics.add(topic)
+        }
+      }
+    } else if (subscribedTopics instanceof Set) {
+      for (const topic of subscribedTopics) {
+        if (topic && topic !== '*' && !topic.includes('messaging/error')) {
+          topics.add(topic)
+        }
+      }
+    } else if (Array.isArray(subscribedTopics)) {
+      for (const topic of subscribedTopics) {
+        if (topic && topic !== '*' && !topic.includes('messaging/error')) {
+          topics.add(topic)
+        }
+      }
+    }
+  }
+
+  return Array.from(topics)
+}
+
+/**
+ * Annotation name for event resource ORD ID mapping.
+ * Applied to event definitions in CDS.
+ */
+const ORD_EVENT_RESOURCE_ANNOTATION = '@ORD.Extensions.eventResource'
+
+/**
+ * Reads event resource mappings from CDS model annotations.
+ *
+ * Scans cds.model.definitions for events annotated with @ORD.Extensions.eventResource
+ * and builds a mapping of event types to their ORD event resource IDs.
+ *
+ * @example
+ * // In CDS:
+ * event sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1
+ *   @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_SALESORDEREVENTS:v1';
+ *
+ * @returns {Map<string, string>} Map of eventType -> ordId
+ */
+function getEventResourceMappingsFromCds() {
+  const LOG = cds.log('event-broker')
+  const mappings = new Map()
+
+  if (!cds.model?.definitions) {
+    LOG.debug?.('No CDS model available')
+    return mappings
+  }
+
+  for (const [name, def] of Object.entries(cds.model.definitions)) {
+    // Check if it's an event definition with the annotation
+    if (def.kind === 'event' && def[ORD_EVENT_RESOURCE_ANNOTATION]) {
+      const ordId = def[ORD_EVENT_RESOURCE_ANNOTATION]
+      if (typeof ordId === 'string' && ordId.trim()) {
+        mappings.set(name, ordId)
+        LOG.debug?.(`Found event ${name} -> ${ordId}`)
+      }
+    }
+  }
+
+  LOG.debug?.(`Found ${mappings.size} annotated events in CDS model`)
+  return mappings
+}
+
+/**
+ * Builds eventResources from CDS annotations and subscribed events.
+ *
+ * Only includes events that are both:
+ * - Annotated with @ORD.Extensions.eventResource in CDS
+ * - Actually subscribed by the application at runtime
+ *
+ * @param {Array<string>} subscribedEvents - Events the app is subscribed to
+ * @param {Map<string, string>} eventResourceMappings - Map of eventType -> ordId from CDS
+ * @returns {Array} eventResources array with {ordId, events} for ORD plugin
+ */
+function buildEventResourcesFromAnnotations(subscribedEvents, eventResourceMappings) {
+  const LOG = cds.log('event-broker')
+  const mappedEvents = new Set()
+
+  // Group subscribed events by their ordId
+  const ordIdToEvents = new Map()
+
+  for (const eventType of subscribedEvents) {
+    const ordId = eventResourceMappings.get(eventType)
+    if (ordId) {
+      if (!ordIdToEvents.has(ordId)) {
+        ordIdToEvents.set(ordId, [])
+      }
+      ordIdToEvents.get(ordId).push(eventType)
+      mappedEvents.add(eventType)
+      LOG.debug?.(`Mapped event ${eventType} to ${ordId}`)
+    }
+  }
+
+  // Build eventResources array
+  const eventResources = []
+  for (const [ordId, events] of ordIdToEvents) {
+    eventResources.push({ ordId, events })
+  }
+
+  // Log unmapped events (subscribed but not annotated)
+  const unmappedEvents = subscribedEvents.filter(e => !mappedEvents.has(e))
+  if (unmappedEvents.length > 0) {
+    LOG.warn(`${unmappedEvents.length} subscribed events not annotated with ${ORD_EVENT_RESOURCE_ANNOTATION}: ${unmappedEvents.join(', ')}`)
+  }
+
+  return eventResources
+}
+
+/**
+ * Register Integration Dependency provider with ORD plugin.
+ * Called once when services are ready.
+ */
+function registerOrdIntegrationDependencyProvider() {
+  const LOG = cds.log('event-broker')
+
+  // Check if ORD plugin is available
+  let ordPlugin
+  try {
+    ordPlugin = require('@cap-js/ord')
+    LOG.info('ORD plugin found, registering Integration Dependency provider')
+  } catch (e) {
+    // ORD plugin not installed - that's fine
+    LOG.debug?.('ORD plugin not installed:', e.message)
+    return
+  }
+
+  if (!ordPlugin.registerIntegrationDependencyProvider) {
+    // Older ORD plugin version without Extension API
+    LOG.debug?.('ORD plugin version does not support Extension API')
+    return
+  }
+
+  // Register provider function
+  ordPlugin.registerIntegrationDependencyProvider(() => {
+    // Get subscribed events at runtime
+    const subscribedEvents = getSubscribedTopics()
+    if (subscribedEvents.length === 0) {
+      LOG.debug?.('No subscribed events found')
+      return null
+    }
+
+    // Get event resource mappings from CDS annotations
+    const eventResourceMappings = getEventResourceMappingsFromCds()
+    if (eventResourceMappings.size === 0) {
+      LOG.debug?.('No events annotated with @ORD.Extensions.eventResource')
+      return null
+    }
+
+    // Build eventResources from annotations and subscribed events
+    const eventResources = buildEventResourcesFromAnnotations(subscribedEvents, eventResourceMappings)
+    if (eventResources.length === 0) {
+      LOG.debug?.('No eventResources could be built from annotations')
+      return null
+    }
+
+    LOG.info(`Providing ${eventResources.length} eventResource(s) for ORD Integration Dependency`)
+    return { eventResources }
+  })
+}
+
+// Register when services are served (runtime only)
+cds.once('served', () => {
+  registerOrdIntegrationDependencyProvider()
+})
+
 module.exports = EventBroker

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -124,6 +124,13 @@ function _validateCertificate(req, res, next) {
   }
 }
 
+/**
+ * Global registry for programmatic ORD event resource mappings.
+ * Populated via EventBroker.subscribe() method.
+ * @type {Map<string, string>} eventType -> ordId
+ */
+const programmaticOrdMappings = new Map()
+
 class EventBroker extends cds.MessagingService {
   async init() {
     await super.init()
@@ -350,6 +357,33 @@ class EventBroker extends cds.MessagingService {
       res.status(500).json({ message: 'Internal Server Error!' })
     }
   }
+
+  /**
+   * Subscribe to an event with ORD metadata.
+   * This consolidates event subscription and ORD Integration Dependency declaration.
+   *
+   * @example
+   * const messaging = await cds.connect.to("messaging")
+   * messaging.subscribe("sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1", {
+   *   eventResourceOrdId: "sap.s4:eventResource:CE_SALESORDEREVENTS:v1"
+   * }, async (event) => {
+   *   console.log("Event received:", event)
+   * })
+   *
+   * @param {string} event - The event type to subscribe to
+   * @param {object} options - Options for ORD Integration Dependency
+   * @param {string} options.eventResourceOrdId - The ORD ID of the event resource (e.g., "sap.s4:eventResource:...")
+   * @param {Function} handler - The event handler function
+   */
+  subscribe(event, options, handler) {
+    // Store ORD mapping if provided
+    if (options?.eventResourceOrdId) {
+      programmaticOrdMappings.set(event, options.eventResourceOrdId)
+    }
+
+    // Delegate to standard messaging.on()
+    return this.on(event, handler)
+  }
 }
 
 // ============================================================================
@@ -462,75 +496,26 @@ function getSubscribedTopics() {
 }
 
 /**
- * Annotation name for event resource ORD ID mapping.
- * Applied to event definitions in CDS.
- */
-const ORD_EVENT_RESOURCE_ANNOTATION = '@ORD.Extensions.eventResource'
-
-/**
- * Reads event resource mappings from CDS model annotations.
- *
- * Scans cds.model.definitions for events annotated with @ORD.Extensions.eventResource
- * and builds a mapping of event types to their ORD event resource IDs.
- *
- * @example
- * // In CDS:
- * event sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1
- *   @ORD.Extensions.eventResource: 'sap.s4:eventResource:CE_SALESORDEREVENTS:v1';
- *
- * @returns {Map<string, string>} Map of eventType -> ordId
- */
-function getEventResourceMappingsFromCds() {
-  const LOG = cds.log('event-broker')
-  const mappings = new Map()
-
-  if (!cds.model?.definitions) {
-    LOG.debug?.('No CDS model available')
-    return mappings
-  }
-
-  for (const [name, def] of Object.entries(cds.model.definitions)) {
-    // Check if it's an event definition with the annotation
-    if (def.kind === 'event' && def[ORD_EVENT_RESOURCE_ANNOTATION]) {
-      const ordId = def[ORD_EVENT_RESOURCE_ANNOTATION]
-      if (typeof ordId === 'string' && ordId.trim()) {
-        mappings.set(name, ordId)
-        LOG.debug?.(`Found event ${name} -> ${ordId}`)
-      }
-    }
-  }
-
-  LOG.debug?.(`Found ${mappings.size} annotated events in CDS model`)
-  return mappings
-}
-
-/**
- * Builds eventResources from CDS annotations and subscribed events.
+ * Builds eventResources from programmatic mappings and subscribed events.
  *
  * Only includes events that are both:
- * - Annotated with @ORD.Extensions.eventResource in CDS
+ * - Registered via messaging.subscribe() with ordId option
  * - Actually subscribed by the application at runtime
  *
  * @param {Array<string>} subscribedEvents - Events the app is subscribed to
- * @param {Map<string, string>} eventResourceMappings - Map of eventType -> ordId from CDS
  * @returns {Array} eventResources array with {ordId, events} for ORD plugin
  */
-function buildEventResourcesFromAnnotations(subscribedEvents, eventResourceMappings) {
-  const LOG = cds.log('event-broker')
-  const mappedEvents = new Set()
-
+function buildEventResources(subscribedEvents) {
   // Group subscribed events by their ordId
   const ordIdToEvents = new Map()
 
   for (const eventType of subscribedEvents) {
-    const ordId = eventResourceMappings.get(eventType)
+    const ordId = programmaticOrdMappings.get(eventType)
     if (ordId) {
       if (!ordIdToEvents.has(ordId)) {
         ordIdToEvents.set(ordId, [])
       }
       ordIdToEvents.get(ordId).push(eventType)
-      mappedEvents.add(eventType)
-      LOG.debug?.(`Mapped event ${eventType} to ${ordId}`)
     }
   }
 
@@ -538,12 +523,6 @@ function buildEventResourcesFromAnnotations(subscribedEvents, eventResourceMappi
   const eventResources = []
   for (const [ordId, events] of ordIdToEvents) {
     eventResources.push({ ordId, events })
-  }
-
-  // Log unmapped events (subscribed but not annotated)
-  const unmappedEvents = subscribedEvents.filter(e => !mappedEvents.has(e))
-  if (unmappedEvents.length > 0) {
-    LOG.warn(`${unmappedEvents.length} subscribed events not annotated with ${ORD_EVENT_RESOURCE_ANNOTATION}: ${unmappedEvents.join(', ')}`)
   }
 
   return eventResources
@@ -554,22 +533,17 @@ function buildEventResourcesFromAnnotations(subscribedEvents, eventResourceMappi
  * Called once when services are ready.
  */
 function registerOrdIntegrationDependencyProvider() {
-  const LOG = cds.log('event-broker')
-
   // Check if ORD plugin is available
   let ordPlugin
   try {
     ordPlugin = require('@cap-js/ord')
-    LOG.info('ORD plugin found, registering Integration Dependency provider')
   } catch (e) {
     // ORD plugin not installed - that's fine
-    LOG.debug?.('ORD plugin not installed:', e.message)
     return
   }
 
   if (!ordPlugin.registerIntegrationDependencyProvider) {
     // Older ORD plugin version without Extension API
-    LOG.debug?.('ORD plugin version does not support Extension API')
     return
   }
 
@@ -578,25 +552,20 @@ function registerOrdIntegrationDependencyProvider() {
     // Get subscribed events at runtime
     const subscribedEvents = getSubscribedTopics()
     if (subscribedEvents.length === 0) {
-      LOG.debug?.('No subscribed events found')
       return null
     }
 
-    // Get event resource mappings from CDS annotations
-    const eventResourceMappings = getEventResourceMappingsFromCds()
-    if (eventResourceMappings.size === 0) {
-      LOG.debug?.('No events annotated with @ORD.Extensions.eventResource')
+    // Check if any programmatic mappings exist
+    if (programmaticOrdMappings.size === 0) {
       return null
     }
 
-    // Build eventResources from annotations and subscribed events
-    const eventResources = buildEventResourcesFromAnnotations(subscribedEvents, eventResourceMappings)
+    // Build eventResources from programmatic mappings and subscribed events
+    const eventResources = buildEventResources(subscribedEvents)
     if (eventResources.length === 0) {
-      LOG.debug?.('No eventResources could be built from annotations')
       return null
     }
 
-    LOG.info(`Providing ${eventResources.length} eventResource(s) for ORD Integration Dependency`)
     return { eventResources }
   })
 }

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -382,6 +382,8 @@ class EventBroker extends cds.MessagingService {
     // Store ORD mapping if provided
     if (options?.eventResourceOrdId) {
       programmaticOrdMappings.set(event, options.eventResourceOrdId)
+      // Publish extension immediately - ORD service listener is already registered by now
+      publishOrdExtension()
     }
 
     // Delegate to standard messaging.on()
@@ -390,59 +392,81 @@ class EventBroker extends cds.MessagingService {
 }
 
 // ============================================================================
-// ORD Integration Dependency Provider
+// ORD Integration Dependency via Event-Based Extension
 // ============================================================================
 
 /**
- * Register Integration Dependency provider with ORD plugin.
+ * Build Integration Dependency extension data for ORD plugin.
+ * Creates the custom ORD content format with integrationDependencies.
+ *
+ * @returns {Object|null} Custom ORD content with integrationDependencies, or null if no mappings
+ */
+function buildIntegrationDependencyExtension() {
+  if (programmaticOrdMappings.size === 0) {
+    return null
+  }
+
+  // Group events by ordId
+  const ordIdToEvents = new Map()
+  for (const [eventType, ordId] of programmaticOrdMappings) {
+    if (!ordIdToEvents.has(ordId)) {
+      ordIdToEvents.set(ordId, [])
+    }
+    ordIdToEvents.get(ordId).push(eventType)
+  }
+
+  // Build eventResources for the aspect
+  const eventResources = []
+  for (const [ordId, events] of ordIdToEvents) {
+    eventResources.push({
+      ordId,
+      subset: events.map(eventType => ({ eventType }))
+    })
+  }
+
+  // Get namespace from cds.env.ord or derive from package name
+  const ordNamespace = cds.env?.ord?.namespace || 'customer.app'
+
+  // Return custom ORD content format
+  return {
+    integrationDependencies: [{
+      ordId: `${ordNamespace}:integrationDependency:consumedEvents:v1`,
+      title: 'Consumed Events',
+      version: '1.0.0',
+      releaseStatus: 'active',
+      visibility: 'public',
+      mandatory: false,
+      aspects: [{
+        title: 'Subscribed Event Types',
+        mandatory: false,
+        eventResources
+      }]
+    }]
+  }
+}
+
+/**
+ * Publish ORD extension via CDS event.
  * Called once when services are ready.
  */
-function registerOrdIntegrationDependencyProvider() {
-  // Check if ORD plugin is available
-  let ordPlugin
-  try {
-    ordPlugin = require('@cap-js/ord')
-  } catch (e) {
-    // ORD plugin not installed - that's fine
+function publishOrdExtension() {
+  const extensionData = buildIntegrationDependencyExtension()
+  if (!extensionData) {
     return
   }
 
-  if (!ordPlugin.registerIntegrationDependencyProvider) {
-    // Older ORD plugin version without Extension API
-    return
-  }
+  LOG.info(`Publishing ORD extension with ${extensionData.integrationDependencies[0].aspects[0].eventResources.length} eventResource(s)`)
 
-  // Register provider function
-  ordPlugin.registerIntegrationDependencyProvider(() => {
-    // Simply return eventResources from programmatic mappings
-    // No need to check subscribedTopics - if subscribe() was called, it's subscribed
-    if (programmaticOrdMappings.size === 0) {
-      return null
-    }
-
-    // Group events by ordId
-    const ordIdToEvents = new Map()
-    for (const [eventType, ordId] of programmaticOrdMappings) {
-      if (!ordIdToEvents.has(ordId)) {
-        ordIdToEvents.set(ordId, [])
-      }
-      ordIdToEvents.get(ordId).push(eventType)
-    }
-
-    // Build eventResources array
-    const eventResources = []
-    for (const [ordId, events] of ordIdToEvents) {
-      eventResources.push({ ordId, events })
-    }
-
-    LOG.info(`Providing ${eventResources.length} eventResource(s) for ORD Integration Dependency`)
-    return { eventResources }
+  // Emit the extension via CDS event
+  cds.emit('ord.extension.publish', {
+    id: 'event-broker-consumed-events',
+    data: extensionData
   })
 }
 
-// Register when services are served (runtime only)
+// Register when services are served (runtime only) - safety net for late emitters
 cds.once('served', () => {
-  registerOrdIntegrationDependencyProvider()
+  publishOrdExtension()
 })
 
 module.exports = EventBroker

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -124,6 +124,9 @@ function _validateCertificate(req, res, next) {
   }
 }
 
+// Logger for ORD integration (outside class context)
+const LOG = cds.log('event-broker')
+
 /**
  * Global registry for programmatic ORD event resource mappings.
  * Populated via EventBroker.subscribe() method.
@@ -391,144 +394,6 @@ class EventBroker extends cds.MessagingService {
 // ============================================================================
 
 /**
- * Known Event Broker service kinds
- */
-const EVENT_BROKER_KINDS = ['event-broker', 'event-broker-ias']
-
-/**
- * Get all Event Broker messaging service configurations from cds.env.requires
- * @returns {Array} Array of { name, config } objects
- */
-function getEventBrokerConfigs() {
-  const envRequires = cds.env?.requires
-  if (!envRequires) return []
-
-  const configs = []
-  for (const [name, config] of Object.entries(envRequires)) {
-    if (!config || typeof config !== 'object') continue
-
-    const isEventBroker =
-      (config.kind && EVENT_BROKER_KINDS.includes(config.kind)) ||
-      (config.vcap?.label && EVENT_BROKER_KINDS.some(kind => config.vcap.label.includes(kind)))
-
-    if (isEventBroker) {
-      configs.push({ name, config })
-    }
-  }
-
-  return configs
-}
-
-/**
- * Extract namespace from Event Broker credentials ceSource.
- *
- * ceSource format: "/default/<namespace>/..." or array with such strings
- * Examples:
- *   "/default/sap.s4/source-system" -> "sap.s4"
- *   ["/default/beb-demo-nodejs/local"] -> "beb-demo-nodejs"
- *
- * @returns {string|null} Extracted namespace or null
- */
-function extractNamespaceFromCeSource() {
-  const configs = getEventBrokerConfigs()
-
-  for (const { config } of configs) {
-    const credentials = config.credentials
-    if (!credentials) continue
-
-    // ceSource can be a string or an array
-    const ceSource = Array.isArray(credentials.ceSource) ? credentials.ceSource[0] : credentials.ceSource
-    if (!ceSource || typeof ceSource !== 'string') continue
-
-    // Parse ceSource: "/default/<namespace>/..." or "/<namespace>/..."
-    const parts = ceSource.split('/').filter(Boolean)
-    if (parts.length < 2) continue
-
-    // If first part is "default", namespace is second part, otherwise first part
-    const namespace = parts[0] === 'default' ? parts[1] : parts[0]
-    if (namespace) return namespace
-  }
-
-  return null
-}
-
-/**
- * Get subscribed topics from Event Broker messaging services at runtime.
- * Reads the subscribedTopics property from initialized messaging services.
- *
- * @returns {Array<string>} Array of subscribed topic names
- */
-function getSubscribedTopics() {
-  const services = cds.services
-  if (!services) return []
-
-  const topics = new Set()
-  const configs = getEventBrokerConfigs()
-
-  for (const { name } of configs) {
-    const service = services[name]
-    if (!service || typeof service.subscribedTopics === 'undefined') continue
-
-    const subscribedTopics = service.subscribedTopics
-
-    if (subscribedTopics instanceof Map) {
-      for (const topic of subscribedTopics.keys()) {
-        if (topic && topic !== '*' && !topic.includes('messaging/error')) {
-          topics.add(topic)
-        }
-      }
-    } else if (subscribedTopics instanceof Set) {
-      for (const topic of subscribedTopics) {
-        if (topic && topic !== '*' && !topic.includes('messaging/error')) {
-          topics.add(topic)
-        }
-      }
-    } else if (Array.isArray(subscribedTopics)) {
-      for (const topic of subscribedTopics) {
-        if (topic && topic !== '*' && !topic.includes('messaging/error')) {
-          topics.add(topic)
-        }
-      }
-    }
-  }
-
-  return Array.from(topics)
-}
-
-/**
- * Builds eventResources from programmatic mappings and subscribed events.
- *
- * Only includes events that are both:
- * - Registered via messaging.subscribe() with ordId option
- * - Actually subscribed by the application at runtime
- *
- * @param {Array<string>} subscribedEvents - Events the app is subscribed to
- * @returns {Array} eventResources array with {ordId, events} for ORD plugin
- */
-function buildEventResources(subscribedEvents) {
-  // Group subscribed events by their ordId
-  const ordIdToEvents = new Map()
-
-  for (const eventType of subscribedEvents) {
-    const ordId = programmaticOrdMappings.get(eventType)
-    if (ordId) {
-      if (!ordIdToEvents.has(ordId)) {
-        ordIdToEvents.set(ordId, [])
-      }
-      ordIdToEvents.get(ordId).push(eventType)
-    }
-  }
-
-  // Build eventResources array
-  const eventResources = []
-  for (const [ordId, events] of ordIdToEvents) {
-    eventResources.push({ ordId, events })
-  }
-
-  return eventResources
-}
-
-/**
  * Register Integration Dependency provider with ORD plugin.
  * Called once when services are ready.
  */
@@ -549,23 +414,28 @@ function registerOrdIntegrationDependencyProvider() {
 
   // Register provider function
   ordPlugin.registerIntegrationDependencyProvider(() => {
-    // Get subscribed events at runtime
-    const subscribedEvents = getSubscribedTopics()
-    if (subscribedEvents.length === 0) {
-      return null
-    }
-
-    // Check if any programmatic mappings exist
+    // Simply return eventResources from programmatic mappings
+    // No need to check subscribedTopics - if subscribe() was called, it's subscribed
     if (programmaticOrdMappings.size === 0) {
       return null
     }
 
-    // Build eventResources from programmatic mappings and subscribed events
-    const eventResources = buildEventResources(subscribedEvents)
-    if (eventResources.length === 0) {
-      return null
+    // Group events by ordId
+    const ordIdToEvents = new Map()
+    for (const [eventType, ordId] of programmaticOrdMappings) {
+      if (!ordIdToEvents.has(ordId)) {
+        ordIdToEvents.set(ordId, [])
+      }
+      ordIdToEvents.get(ordId).push(eventType)
     }
 
+    // Build eventResources array
+    const eventResources = []
+    for (const [ordId, events] of ordIdToEvents) {
+      eventResources.push({ ordId, events })
+    }
+
+    LOG.info(`Providing ${eventResources.length} eventResource(s) for ORD Integration Dependency`)
     return { eventResources }
   })
 }


### PR DESCRIPTION
# feat: Add ORD Integration Dependency support via messaging.subscribe()

## Summary

This PR adds support for generating ORD **Integration Dependencies** for consumed events using the `messaging.subscribe()` method with an `eventResourceOrdId` option.

When both `@cap-js/event-broker` and `@cap-js/ord` (≥ 1.6) plugins are installed, consumed events are automatically documented in the application's ORD metadata.

## Motivation

Applications using Event Broker to consume external CloudEvents (e.g., from S/4HANA) should declare these dependencies in their ORD document for:

- **Discoverability**: External tools can see which events an application depends on
- **Governance**: Complete dependency graph for event-driven integrations
- **Alignment**: Matches Java CAP plugin (`cds-feature-event-hub`) behavior

## Changes

### Modified Files

| File            | Description                                                         |
| --------------- | ------------------------------------------------------------------- |
| `cds-plugin.js` | Added `subscribe()` method with `eventResourceOrdId` option support |
| `README.md`     | Added ORD Integration documentation                                 |

## Usage

### Subscribe to events with ORD metadata

Use `messaging.subscribe()` with the `eventResourceOrdId` option to both subscribe to events and declare them in ORD:

```javascript
// srv/server.js
const cds = require("@sap/cds");

cds.once("served", async () => {
  const messaging = await cds.connect.to("messaging");

  // Subscribe to S/4HANA SalesOrder events
  messaging.subscribe(
    "sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1",
    {
      eventResourceOrdId: "sap.s4:eventResource:CE_SALESORDEREVENTS:v1",
    },
    async (msg) => {
      console.log("Received SalesOrder.Changed event:", msg.data);
    },
  );

  // Subscribe to BusinessPartner events
  messaging.subscribe(
    "sap.s4.beh.businesspartner.v1.BusinessPartner.Created.v1",
    {
      eventResourceOrdId: "sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1",
    },
    async (msg) => {
      console.log("Received BusinessPartner.Created event:", msg.data);
    },
  );
});
```

### Result: ORD Integration Dependency

At runtime, the ORD document at `/.well-known/open-resource-discovery` includes:

```json
{
  "integrationDependencies": [
    {
      "ordId": "customer.myapp:integrationDependency:consumedEvents:v1",
      "title": "Consumed Events",
      "aspects": [
        {
          "title": "Subscribed Event Types",
          "eventResources": [
            {
              "ordId": "sap.s4:eventResource:CE_SALESORDEREVENTS:v1",
              "subset": [
                {
                  "eventType": "sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1"
                }
              ]
            },
            {
              "ordId": "sap.s4:eventResource:CE_BUSINESSPARTNEREVENTS:v1",
              "subset": [
                {
                  "eventType": "sap.s4.beh.businesspartner.v1.BusinessPartner.Created.v1"
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```

### Multiple Event Types per Event Resource

When multiple events belong to the same event resource, they are automatically grouped:

```javascript
// Both SalesOrder events share the same event resource
messaging.subscribe(
  "sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1",
  { eventResourceOrdId: "sap.s4:eventResource:CE_SALESORDEREVENTS:v1" },
  handler,
);
messaging.subscribe(
  "sap.s4.beh.salesorder.v1.SalesOrder.Created.v1",
  { eventResourceOrdId: "sap.s4:eventResource:CE_SALESORDEREVENTS:v1" },
  handler,
);
```

Results in:

```json
{
  "ordId": "sap.s4:eventResource:CE_SALESORDEREVENTS:v1",
  "subset": [
    { "eventType": "sap.s4.beh.salesorder.v1.SalesOrder.Changed.v1" },
    { "eventType": "sap.s4.beh.salesorder.v1.SalesOrder.Created.v1" }
  ]
}
```

## How It Works

1. **`messaging.subscribe()` calls**: The plugin intercepts `subscribe()` calls, stores the event-type → ORD-ID mapping, and immediately emits `ord.extension.publish` via `cds.emit()`
2. **`ord.extension.publish` event**: `@cap-js/ord` (≥ 1.6) listens for this CDS event and stores the extension data keyed by `id`
3. **At request time**: The ORD service includes all stored extensions when building the ORD document
4. **Safety net**: `cds.once('served')` re-emits the extension to cover cases where `subscribe()` is called before the ORD service is initialized

### subscribe() Method Signature

```javascript
messaging.subscribe(eventType, options, handler);
```

| Parameter   | Type       | Description                            |
| ----------- | ---------- | -------------------------------------- |
| `eventType` | `string`   | The fully qualified event type name    |
| `options`   | `object`   | Options including `eventResourceOrdId` |
| `handler`   | `function` | Event handler callback                 |

The `eventResourceOrdId` option specifies the ORD ID of the external Event Resource that contains this event type.

### Internal Extension Format

The plugin emits:

```javascript
cds.emit("ord.extension.publish", {
  id: "event-broker-consumed-events",
  data: {
    integrationDependencies: [
      {
        /* ... */
      },
    ],
  },
});
```

The ORD plugin merges all received extensions into the final ORD document by their `id`.

## Design Decisions

### Why messaging.subscribe() instead of CDS annotations?

| Approach                         | Pros                                      | Cons                                        |
| -------------------------------- | ----------------------------------------- | ------------------------------------------- |
| **CDS annotations**              | CAP-idiomatic, visible in model           | Requires separate CDS + code, easy to drift |
| **messaging.subscribe()** (this) | Single location, directly tied to handler | Only runtime, not build-time                |

Using `subscribe()` consolidates event subscription and ORD declaration in one place. This ensures the ORD metadata always matches what the application actually subscribes to.

### Why cds.emit('ord.extension.publish') instead of a callback registry?

The event-based approach (`cds.emit`) is a standard CDS pattern for decoupled plugin communication. It requires no shared module reference between `@cap-js/event-broker` and `@cap-js/ord` — only a known event name as contract.

### Runtime-Only Support

Integration Dependencies are only generated at runtime, matching the Java plugin behavior. Build-time would require parsing service implementation code.

## Comparison with Java Plugin

| Feature           | Java (`cds-feature-event-hub`)                 | Node.js (`@cap-js/event-broker`)              |
| ----------------- | ---------------------------------------------- | --------------------------------------------- |
| Runtime Support   | SPI-based (`OrdIntegrationDependencyProvider`) | `cds.emit('ord.extension.publish')` CDS event |
| Configuration     | No config, reads from subscriptions            | `eventResourceOrdId` in `subscribe()` call    |
| Event Detection   | Spring bean introspection                      | `subscribe()` method interception             |
| Multiple Services | Aggregated                                     | Aggregated                                    |

## Checklist

- [x] README.md updated with new subscribe-based approach
- [x] subscribe() method added to messaging service
- [x] Event resources grouped by ordId
- [x] Plugin loads successfully
- [x] End-to-end verified on Cloud Foundry

## References

- `@cap-js/ord` ≥ 1.6 required (adds `ord.extension.publish` CDS event support)
- Related ORD PR: <https://github.com/cap-js/ord/pull/402>
