### PR TITLE
fix(tests): adapt assertions to cds-test 1.0.0 error format

### DIFF
--- a/test/event-broker-ias-multitenant/event-broker.test.js
+++ b/test/event-broker-ias-multitenant/event-broker.test.js
@@ -105,14 +105,14 @@ describe('event-broker service with ias auth', () => {
   test('request without JWT token', async () => {
     await expect(POST(`/-/cds/event-broker/webhook`)).rejects.toHaveProperty(
       'message',
-      expect.stringMatching('Request failed with status code 401')
+      expect.stringMatching(/401/)
     )
   })
 
   test('request with invalid JWT token', async () => {
     await expect(
       POST(`/-/cds/event-broker/webhook`, { some: 'data' }, { headers: { Authorization: 'Bearer invalidtoken' } })
-    ).rejects.toHaveProperty('message', expect.stringMatching('Request failed with status code 401'))
+    ).rejects.toHaveProperty('message', expect.stringMatching(/401/))
   })
 
   test('Event broker mock event - messaging service ', done => {
@@ -198,7 +198,7 @@ describe('event-broker service with ias auth', () => {
       await POST(`/-/cds/event-broker/webhook`, { data: DATA, ...HEADERS }, { headers })
       expect(1).toBe('should not reach here')
     } catch (e) {
-      expect(e.code).toBe('ERR_BAD_RESPONSE')
+      expect(e.status).toBe(500)
     }
   })
 })

--- a/test/event-broker-ias-single-tenant/event-broker.test.js
+++ b/test/event-broker-ias-single-tenant/event-broker.test.js
@@ -86,14 +86,14 @@ describe('event-broker service with ias auth for single tenant scenario', () => 
   test('request without JWT token', async () => {
     await expect(POST(`/-/cds/event-broker/webhook`)).rejects.toHaveProperty(
       'message',
-      expect.stringMatching('Request failed with status code 401')
+      expect.stringMatching(/401/)
     )
   })
 
   test('request with invalid JWT token', async () => {
     await expect(
       POST(`/-/cds/event-broker/webhook`, { some: 'data' }, { headers: { Authorization: 'Bearer invalidtoken' } })
-    ).rejects.toHaveProperty('message', expect.stringMatching('Request failed with status code 401'))
+    ).rejects.toHaveProperty('message', expect.stringMatching(/401/))
   })
 
   test('Event broker mock event - messaging service ', done => {
@@ -179,7 +179,7 @@ describe('event-broker service with ias auth for single tenant scenario', () => 
       await POST(`/-/cds/event-broker/webhook`, { data: DATA, ...HEADERS }, { headers })
       expect(1).toBe('should not reach here')
     } catch (e) {
-      expect(e.code).toBe('ERR_BAD_RESPONSE')
+      expect(e.status).toBe(500)
     }
   })
 })

--- a/test/event-broker-x509-multitenant/event-broker.test.js
+++ b/test/event-broker-x509-multitenant/event-broker.test.js
@@ -102,7 +102,7 @@ describe('event-broker service', () => {
   test('request without client cert', async () => {
     await expect(POST(`/-/cds/event-broker/webhook`)).rejects.toHaveProperty(
       'message',
-      expect.stringMatching('Request failed with status code 401')
+      expect.stringMatching(/401/)
     )
   })
 


### PR DESCRIPTION
The upgrade of @cap-js/cds-test to 1.0.0 replaced axios with the native Fetch API. This changes the error format thrown by HTTP methods:

- Error messages changed from 'Request failed with status code 401' to '401 - Unauthorized', so assertions now match /401/ instead.
- Error code 'ERR_BAD_RESPONSE' (axios-specific) is no longer set; the status is now available on e.status, so assertions use e.status === 500.

fyi @chgeo , @sjvans 