### PR TITLE
chore(cds10): do not rely on cds.User.tokenInfo

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -295,14 +295,12 @@ class EventBroker extends cds.MessagingService {
         return next(err)
       })
       cds.app.use(webhookBasePath, (_req, res, next) => {
-        if (
-          cds.context.user.is('system-user') &&
-          cds.context.user.authInfo.token.azp === this.options.credentials.ias.clientId
-        ) {
+        const { user } = cds.context
+        if (user.is('system-user') && (user.authInfo?.token ?? user.tokenInfo).azp === this.options.credentials.ias.clientId) {
           // the token was fetched by event broker -> OK
           return next()
         }
-        if (cds.context.user.is('internal-user')) {
+        if (user.is('internal-user')) {
           // the token was fetched by own credentials -> OK (for testing, developer dashboard, etc.)
           return next()
         }

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -297,7 +297,7 @@ class EventBroker extends cds.MessagingService {
       cds.app.use(webhookBasePath, (_req, res, next) => {
         if (
           cds.context.user.is('system-user') &&
-          cds.context.user.tokenInfo.azp === this.options.credentials.ias.clientId
+          cds.context.user.authInfo.token.azp === this.options.credentials.ias.clientId
         ) {
           // the token was fetched by event broker -> OK
           return next()

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@cap-js/event-broker": "file:.",
-    "@cap-js/cds-test": ">=0",
+    "@cap-js/cds-test": "^0",
     "@cap-js/sqlite": ">=1",
     "@sap-cloud-sdk/resilience": "^4.0.0",
     "@sap/xssec": "^4.2.4"


### PR DESCRIPTION
cds10. drops support for cds.User.tokenInfo. Use cds.User.authInfo.token instead.