### PR TITLE
chore: NPM_CONFIG_IGNORE_SCRIPTS instead of .npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ permissions:
 on:
   workflow_dispatch:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: true
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -21,6 +24,7 @@ jobs:
         run: |
           npm i -g @sap/cds-dk
           npm i
+          npm explore better-sqlite3 -- npm run install
           npm run lint
           npm run test
       - name: get version

--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,3 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-
-# custom
-package-lock.json
-!test/event-broker-ias-multitenant/package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true


### PR DESCRIPTION
# Replace `.npmrc` with `NPM_CONFIG_IGNORE_SCRIPTS` Environment Variable

### Chore

🔧 Replaced the `.npmrc` file approach for ignoring npm scripts with the `NPM_CONFIG_IGNORE_SCRIPTS=true` environment variable set directly in the CI/CD workflow files. This is a cleaner and more explicit way to prevent post-install scripts from running during automated workflows.

Since `NPM_CONFIG_IGNORE_SCRIPTS` now suppresses all install scripts globally, the `better-sqlite3` native module must be built explicitly — this is handled by adding `npm explore better-sqlite3 -- npm run install` in the release workflow.

### Changes

* `.github/workflows/ci.yml`: Added `NPM_CONFIG_IGNORE_SCRIPTS: true` as a top-level environment variable to prevent npm lifecycle scripts from running during CI.
* `.github/workflows/release.yml`: Added `NPM_CONFIG_IGNORE_SCRIPTS: true` as a top-level environment variable and added an explicit step to build `better-sqlite3` since its install script is now skipped globally.
* `.npmrc`: Removed — previously used to configure `ignore-scripts`; now superseded by the environment variable approach.
* `.gitignore`: Removed custom entries for `package-lock.json` (and its exception for a specific test directory).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Event Trigger: `pull_request.opened`
- Correlation ID: `b22a5a4a-b029-4c4b-bb4e-90fc7ef8360e`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
