### PR TITLE
ci: workflow changes for automated release and version increase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
-      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f @sap/cds@8 @cap-js/sqlite@1; fi
+      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f @sap/cds@8 @cap-js/sqlite@1; elif [ ${{ matrix.cds-version }} -eq 9 ]; then npm i -f @sap/cds@9 @cap-js/sqlite@2; fi
       - run: npm explore better-sqlite3 -- npm run install
       - run: cds v
       - run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,19 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      #version:
+      #  description: 'version to release, e.g. v0.3.3'
+      #  required: true
+      #  default: 'v0.3.2'
+      patchlevel:
+        type: choice
+        default: patch
+        description: Select the level of the version auto-increase
+        options:
+          - patch
+          - minor
+          - major
 
 env:
   NPM_CONFIG_IGNORE_SCRIPTS: true
@@ -27,9 +40,41 @@ jobs:
           npm explore better-sqlite3 -- npm run install
           npm run lint
           npm run test
-      - name: get version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.3.1
+      #- name: Create Tag 
+      #  uses: rickstaa/action-create-tag@v1.7.2
+      #  with:
+      #    tag: ${{ github.event.inputs.version }}
+      - name:  'Automated Version Bump and Tag Creation'
+        id: bump_version
+        uses:  'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version-type: ${{ github.event.inputs.patchlevel }}
+          target-branch: ${{ github.ref_name }}
+          commit-message: 'CI: bumps version to {{version}} [skip ci]'
+          tag-prefix: 'v'
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          tag: ${{ steps.bump_version.outputs.newTag }}
+          includeInvalidCommits: true
+          excludeTypes: docs,build,CI
+      #- name: DebugOut changelog.md
+      #  run: |
+      #    echo "DEBUGOUT: "
+      #    cat CHANGELOG.md
+      - name: Commit CHANGELOG.md
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          branch: ${{ github.ref_name }}
+          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
+          file_pattern: CHANGELOG.md
+      #- name: get version
+      #  id: package-version
+      #  uses: martinbeentjes/npm-get-version-action@v1.3.1
       - name: parse changelog
         id: parse-changelog
         uses: schwma/parse-changelog-action@v1.2.0
@@ -38,6 +83,6 @@ jobs:
       - name: create a GitHub release
         uses: ncipollo/release-action@v1
         with:
-          tag: 'v${{ steps.package-version.outputs.current-version }}'
+          tag: '${{ steps.bump_version.outputs.newTag }}' # 'v${{ steps.package-version.outputs.current-version }}'
           body: '${{ steps.parse-changelog.outputs.body }}'
       - run: npm publish --access public --provenance


### PR DESCRIPTION
this workflow now 
- bumps the version in "package.json" based on the selected version increase level
- 3 levels can be selected (at the start of the workflow):
    - patch (default)
    - minor
    - major
- creates a tag based on this new version (e.g. "v0.3.2" )
- updates the CHANGELOG.md file based on Conventional Commits
- creates a release (includes Release notes from CHANGELOG.md)
- uploads it to npm